### PR TITLE
change permissions on setup.sql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY ./*.php /var/www/html/
 COPY ./.docker/emulate_admin.py /app/emulate_admin.py
 COPY ./.docker/entrypoint.sh /app/entrypoint.sh
 COPY ./.docker/setup.sql /app/setup.sql
+RUN chmod a+r /app/setup.sql
 
 # Configure crontab
 COPY ./.docker/emulate_cron /etc/cron.d/emulate_admin


### PR DESCRIPTION
My docker run failed because it couldn't access the /app/setup.sql as the postgres user.

So it loaded up the site without a database.