### PR TITLE
update index.php to fix caching of templates

### DIFF
--- a/index.php
+++ b/index.php
@@ -55,7 +55,8 @@
                     require_once 'vendor/autoload.php';
                     $smarty = new Smarty();
                     $smarty->assign("username", $_SESSION['username']);
-                    $smarty->debugging = true; 
+                    $smarty->debugging = true;
+                    $smarty->force_compile = true;
                     echo $smarty->fetch("motd.tpl").'<br>';
 
                     $ret = pg_query($db, "select * from motd_images order by iid desc limit 3;");


### PR DESCRIPTION
caching default is 3600 seconds (an hour).  set it to force a recompile each time it is loaded allows the tester to see changes quicker.